### PR TITLE
Some fixes/amends from trying to use DragTree

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ collection, editing and publishing of bibliographic data.
 
 > **NOTE: This is the development version based on Yii2 and PHP7, which can be incomplete, unstable or even completely unfunctional. If you want a stable working version of Bibliograph, use the [current master version](https://github.com/cboulanger/bibliograph/tree/master)**
 
-- [Installation](doc/install.md)
+- [Installation](doc/dev/install.md)
 - [Release Notes](release-notes.md)
 
 Bibliograph
@@ -52,14 +52,14 @@ Bibliograph can be used by
 - Fully open source, can be easily adapted and extended by plugins. 
 
 ## Installation and Deployment
-See [here](doc/install.md).
+See [here](doc/dev/install.md).
 
 ## Support
 - Bugs and feature requests should be registered as [github issues](https://github.com/cboulanger/bibliograph/issues).
 
 ## Development & Roadmap
-- You can [hack the code](doc/development.md) and make it better;
-- The current roadmap is [here](doc/roadmap.md);
+- You can [hack the code](doc/dev/development.md) and make it better;
+- The current roadmap is [here](doc/dev/roadmap.md);
 - If you wish to sponsor a feature, please contact info at bibliograph dot org.
 
 ## How to contribute

--- a/src/client/bibliograph/source/class/qcl/ui/treevirtual/DragDropTree.js
+++ b/src/client/bibliograph/source/class/qcl/ui/treevirtual/DragDropTree.js
@@ -533,7 +533,7 @@ qx.Class.define("qcl.ui.treevirtual.DragDropTree",
         // drag cursor
         qx.ui.core.DragDropCursor.getInstance().setAction(e.getCurrentAction());
       }  else {
-        e.preventDefault();
+        //e.preventDefault();
         e.getManager().setDropAllowed(false);
         //qx.ui.core.DragDropCursor.getInstance().resetAction();
       }

--- a/src/client/bibliograph/source/class/qcl/ui/treevirtual/DragDropTree.js
+++ b/src/client/bibliograph/source/class/qcl/ui/treevirtual/DragDropTree.js
@@ -271,7 +271,10 @@ qx.Class.define("qcl.ui.treevirtual.DragDropTree",
      * The indicator widget
      */
     __indicator: null,
-    
+
+    __dragActionTimeout: null,
+    __lastDebugMessage: null,
+    __scrollFunctionId: null,
     /*
     ---------------------------------------------------------------------------
        INTERNAL METHODS

--- a/src/client/bibliograph/source/class/qcl/ui/treevirtual/DragDropTree.js
+++ b/src/client/bibliograph/source/class/qcl/ui/treevirtual/DragDropTree.js
@@ -281,7 +281,7 @@ qx.Class.define("qcl.ui.treevirtual.DragDropTree",
     /**
      * Outputs verbose drag session debug messages, suppressing duplicate
      * messages. Can be turned off using the `debugDragSession` property.
-     * @param msg
+     * @param msg {String}
      */
     dragDebug : function(msg){
       if( msg !== this.__lastDebugMessage && this.getDebugDragSession()){
@@ -398,8 +398,8 @@ qx.Class.define("qcl.ui.treevirtual.DragDropTree",
   
     /**
      * Applies the "dragAction" property
-     * @param value {Boolean}
-     * @param old {Boolean}
+     * @param value {String}
+     * @param old {String}
      * @private
      */
     _applyDragAction: function (value, old) {
@@ -592,7 +592,7 @@ qx.Class.define("qcl.ui.treevirtual.DragDropTree",
     /**
      * Opens a node if the cursor hovers over it for a certain amount of
      * time (currently, 500ms)
-     * @param node
+     * @param node {Object}
      * @private
      */
     _openNodeAfterTimeout : function(node){

--- a/src/client/bibliograph/source/class/qcl/ui/treevirtual/DragDropTree.js
+++ b/src/client/bibliograph/source/class/qcl/ui/treevirtual/DragDropTree.js
@@ -306,7 +306,7 @@ qx.Class.define("qcl.ui.treevirtual.DragDropTree",
         maxHeight : 5,
         anonymous : true,
         backgroundColor : "black",
-        droppable: true,
+        droppable: true
       });
       this._hideIndicator();
       
@@ -335,7 +335,7 @@ qx.Class.define("qcl.ui.treevirtual.DragDropTree",
      * @param y {Number}
      * @private
      */
-    _setIndicatorPosition( x,y  ){
+    _setIndicatorPosition: function( x,y  ){
       //this.__indicator.setDomTop(y);
     },
     


### PR DESCRIPTION
Hi, I've been trying to implement the DragTree today after you suggested this to one of my colleagues in the Qooxdoo gitter room (cle538) a while back (May). It seems to be relatively successful but for a few changes - the main reason for those being we're not yet using ES6, and still using the Python compiler. 

Aside from documentation reference updates and some linting fixes, the main change to get it working for me was to comment out a e.preventDefault when starting dragging in the tree. With this line of code in place, the drag was instantly killed because the target node was the same as the source node.

See what you think. :)